### PR TITLE
Declare HPOS Compatibility

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -91,6 +91,12 @@ class Plugin extends Framework\SV_WC_Payment_Gateway_Plugin {
 	 * @since 1.0.0
 	 */
 	private function setup_hooks() {
+		// Declare HPOS compatibility
+		add_action( 'before_woocommerce_init', function() {
+			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+			}
+		} );
 
 		if ( ! strncmp( get_option( 'woocommerce_default_country' ), 'US:', 3 ) ) {
 


### PR DESCRIPTION
Followed this guide: https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book

Searched repo for regex `/post_updated_messages|do_meta_boxes|enter_title_here|edit_form_before_permalink|edit_form_after_title|edit_form_after_editor|submitpage_box|submitpost_box|edit_form_advanced|dbx_post_sidebar|manage_shop_order_posts_columns|manage_shop_order_posts_custom_column/` per guide

Found 0 results of direct table access. Found supported `WC_Order` class usage. Plugin should be HPOS compatible.